### PR TITLE
fix: correct JSON syntax errors in Proofpoint parser config

### DIFF
--- a/parsers/community/proofpoint_proofpoint_logs-latest/proofpoint_proofpoint_logs.conf
+++ b/parsers/community/proofpoint_proofpoint_logs-latest/proofpoint_proofpoint_logs.conf
@@ -151,13 +151,13 @@
              output:  "device.risk_score",
              match:   ".*",
              replace: "$0"
-           }
+           },
            {
              input:   "subject",
              output:  "email.subject",
              match:   ".*",
              replace: "$0"
-           },,
+           },
            {
              input:   "toAddresses",
              output:  "email.delivered_to",


### PR DESCRIPTION
- Fixed invalid comma after closing brace in field mapping section
- Removed duplicate comma between subject and toAddresses mappings