### PR TITLE
Updated Proofpoint and Wiz parsers with additional field mappings

### DIFF
--- a/parsers/community/proofpoint_proofpoint_logs-latest/proofpoint_proofpoint_logs.conf
+++ b/parsers/community/proofpoint_proofpoint_logs-latest/proofpoint_proofpoint_logs.conf
@@ -21,17 +21,41 @@
              replace: "$0"
            },  
            {
-             input:   "ccAddresses",
-             output:  "email.cc",
+             input:   "GUID",
+             output:  "email.uid",
              match:   ".*",
              replace: "$0"
            },
            {
-             input:   "cluster",
-             output:  "email_activity.cluster",
+             input:   "messageID",
+             output:  "email.uid",
              match:   ".*",
              replace: "$0"
            },
+            {
+              input:   "ccAddresses",
+              output:  "email.cc",
+              match:   ".*",
+              replace: "$0"
+            },
+           {
+             input:   "recipient",
+             output:  "email.to",
+             match:   ".*",
+             replace: "$0"
+           },
+           {
+             input:   "toAddresses",
+             output:  "email.to",
+             match:   ".*",
+             replace: "$0"
+           },
+            {
+              input:   "cluster",
+              output:  "email_activity.cluster",
+              match:   ".*",
+              replace: "$0"
+            },
            {
              input:   "completelyRewritten",
              output:  "message.is_rewritten",
@@ -89,6 +113,18 @@
            {
              input:   "messageTime",
              output:  "email_activity.time_dt",
+             match:   ".*",
+             replace: "$0"
+           },
+           {
+             input:   "messageTime",
+             output:  "time",
+             match:   ".*",
+             replace: "$0"
+           },
+           {
+             input:   "messageTime",
+             output:  "metadata.original_time",
              match:   ".*",
              replace: "$0"
            },

--- a/parsers/community/wiz_cloud-latest/wiz_cloud.conf
+++ b/parsers/community/wiz_cloud-latest/wiz_cloud.conf
@@ -37,6 +37,44 @@
               "field": "time",
               "type": "iso8601TimestampToEpochSec"
             }
+          },
+          {
+            "constant": { "value": 2001, "field": "class_uid" }
+          },
+          {
+            "constant": { "value": "Security Finding", "field": "class_name" }
+          },
+          {
+            "constant": { "value": 2, "field": "category_uid" }
+          },
+          {
+            "constant": { "value": "Findings", "field": "category_name" }
+          },
+          {
+            "copy": { "from": "unmapped.type_uid", "to": "type_uid" }
+          },
+          {
+            "constant": {
+              "value": "Security Finding: Other",
+              "field": "type_name",
+              "predicate": "type_uid = '200199' OR type_uid = 200199"
+            }
+          },
+          {
+            "copy": { "from": "unmapped.activity_id", "to": "activity_id" }
+          },
+          {
+            "constant": {
+              "value": "Other",
+              "field": "activity_name",
+              "predicate": "activity_id = '99' OR activity_id = 99"
+            }
+          },
+          {
+            "copy": { "from": "unmapped.updatedAt", "to": "metadata.original_time" }
+          },
+          {
+            "copy": { "from": "unmapped.createdAt", "to": "metadata.original_time", "predicate": "metadata.original_time = '' OR metadata.original_time = null" }
           }
         ]
       }


### PR DESCRIPTION
- Proofpoint: Added email.uid mappings for GUID and messageID, email.to mappings for recipient and toAddresses, and messageTime mappings for time and metadata.original_time
- Wiz: Added OCSF schema fields including class_uid (2001), class_name, category_uid (2), type_uid/type_name, activity_id/activity_name, and metadata.original_time mappings from updatedAt/createdAt