### PR TITLE
Update .gitignore for local documentation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ CLAUDE.md
 *.claude
 .cursorrules
 .claude-config
+
+# Local documentation #
+#######################
+LOCAL_*.md
+LOCAL_*.txt
+*_LOCAL_ONLY.*


### PR DESCRIPTION
## Summary
- Add patterns to exclude local-only documentation files
- Prevents accidental commits of sensitive local docs like RCAs

## Changes
- Added `LOCAL_*.md` pattern to .gitignore
- Added `LOCAL_*.txt` pattern to .gitignore  
- Added `*_LOCAL_ONLY.*` pattern to .gitignore

## Context
Following up on security remediation work, this ensures that local documentation (like RCA reports) stays private and is never committed to the repository.

## Test Plan
- [ ] Verify LOCAL_* files are ignored by git
- [ ] Confirm existing .gitignore rules still work

🤖 Generated with [Claude Code](https://claude.ai/code)