### PR TITLE
Add QNAP QuLog parser

### DIFF
--- a/parsers/community/qnap_qulog_logs-latest/metadata.yaml
+++ b/parsers/community/qnap_qulog_logs-latest/metadata.yaml
@@ -1,0 +1,19 @@
+metadata_details:
+  purpose: Parser for QNAP QuLog Center logs (RFC 5424 structured-data syslog), normalising
+    QuLog@Access events into OCSF Authentication (3002) and preserving QuLog@Event NAS
+    system events as faithful, lightly-mapped administrative events.
+  datasource_vendor: qnap
+  datasource_name: QNAP QuLog Center
+  dataSource: ocsf
+  format: OCSF
+  ingestion_method: syslog
+  dependency_summary: Requires QuLog Center to forward logs via syslog (RFC 5424) with
+    the QuLog@Access and QuLog@Event structured-data elements intact.
+  performance_impact: Minimal - one syslog frame match plus a repeating key=value extractor
+    over the structured-data block.
+  tags: qnap, qulog, nas, syslog, rfc5424, ocsf, authentication, parser
+  version: 1.2.1
+  author: Mario Ciccarelli (mario.ciccarelli@sentinelone.com)
+  ocsf_classes:
+    - QuLog@Access -> Authentication (3002)
+    - QuLog@Event  -> unclassified administrative event (no class_uid)

--- a/parsers/community/qnap_qulog_logs-latest/qnap_qulog.conf
+++ b/parsers/community/qnap_qulog_logs-latest/qnap_qulog.conf
@@ -1,0 +1,178 @@
+// QNAP QuLog Center — RFC 5424 structured-data syslog.
+//
+// Two structured-data IDs share one syslog frame:
+//   QuLog@Access -> user access / login / logout  -> OCSF Authentication (3002)
+//   QuLog@Event  -> heterogeneous NAS system events (storage, power, app center,
+//                   hardware, network, shared folders) -> kept as a faithful,
+//                   unclassified administrative event (no class_uid; see handoff).
+//
+// NOTE on QNAP numeric enums: `action` (256/512/1024) and `action_result` are QNAP
+// internal codes. From this sample they map consistently as
+//   action 512 = Logon (success, severity <30>),
+//   action 256 = Logon (failure, severity <28>),
+//   action 1024 = Logoff.
+// The raw codes are preserved (action_id, status_code, unmapped.qnap_service_id) so
+// nothing is lost if the enum needs correcting against QuLog documentation.
+
+{
+  timezone: "UTC",
+
+  attributes: {
+    // Required pipeline defaults — present on every parser.
+    "metadata.version":    "1.2.1",
+    "dataSource.category": "security",
+    "dataSource.name":     "QNAP QuLog Center",
+    "dataSource.vendor":   "QNAP",
+    "metadata.product.vendor_name": "QNAP",
+    "metadata.product.name":        "QuLog Center"
+  },
+
+  patterns: {
+    // ISO-8601 timestamp with embedded UTC offset, e.g. 2026-07-02T11:46:14.390+01:00
+    iso:     "\\d{4}-\\d{2}-\\d{2}T[0-9:.+\\-Z]+",
+    // Quoted-value body: everything up to the closing double quote (matches empty "").
+    noQuote: "[^\"]*",
+    // Rest-of-line (the free-text message after the SD block).
+    rest:    "[^\\r\\n]*"
+  },
+
+  formats: [
+    // ---- QuLog@Access frame -> Authentication (3002) -------------------------
+    {
+      attributes: {
+        "metadata.log_provider": "QuLog@Access",
+        "class_uid":     3002,
+        "class_name":    "Authentication",
+        "category_uid":  3,
+        "category_name": "Identity & Access Management"
+      },
+      // <PRI>VER TIMESTAMP HOST <qulogd: PID MSGID> [QuLog@Access ...] MESSAGE
+      // sl_hdr swallows "qulogd: 12414 - " (everything up to the SD '[').
+      format: "<$log_priority=digits$>$sl_ver=digits$ $time=iso$ $device.hostname$ $sl_hdr{regex=[^\\[]*}$\\[QuLog@Access $sd_raw{regex=[^\\]]*}$\\] $msg=rest$"
+    },
+
+    // ---- QuLog@Event frame -> unclassified administrative event --------------
+    {
+      attributes: {
+        "metadata.log_provider": "QuLog@Event"
+      },
+      format: "<$log_priority=digits$>$sl_ver=digits$ $time=iso$ $device.hostname$ $sl_hdr{regex=[^\\[]*}$\\[QuLog@Event $sd_raw{regex=[^\\]]*}$\\] $msg=rest$"
+    },
+
+    // ---- Shared key="value" extractor over the SD block ---------------------
+    // repeat:true re-applies at the position after the last match, pulling every
+    // key="value" pair out of the structured-data block regardless of SD type.
+    // skipNumericConversion keeps opaque IDs (message_id="0155") as strings.
+    {
+      format: ".*$_=identifier$=\"$_=noQuote$\"",
+      repeat: true,
+      skipNumericConversion: true
+    }
+  ],
+
+  mappings: {
+    version: 1,
+    mappings: [
+
+      // ===== QuLog@Access -> OCSF Authentication (3002) ======================
+      {
+        predicate: "metadata.log_provider == 'QuLog@Access'",
+        transformations: [
+          // Severity from syslog priority (facility 3: 30=info, 28=warning).
+          { constant: { field: "severity_id", value: 1, predicate: "log_priority == '30'" } },
+          { constant: { field: "severity",    value: "Informational", predicate: "log_priority == '30'" } },
+          { constant: { field: "severity_id", value: 3, predicate: "log_priority == '28'" } },
+          { constant: { field: "severity",    value: "Medium",        predicate: "log_priority == '28'" } },
+
+          // Activity + status from the QNAP action code (see header NOTE).
+          { constant: { field: "activity_id",   value: 1,         predicate: "action == '512'" } },
+          { constant: { field: "activity_name", value: "Logon",   predicate: "action == '512'" } },
+          { constant: { field: "status_id",     value: 1,         predicate: "action == '512'" } },
+          { constant: { field: "status",        value: "Success", predicate: "action == '512'" } },
+
+          { constant: { field: "activity_id",   value: 1,         predicate: "action == '256'" } },
+          { constant: { field: "activity_name", value: "Logon",   predicate: "action == '256'" } },
+          { constant: { field: "status_id",     value: 2,         predicate: "action == '256'" } },
+          { constant: { field: "status",        value: "Failure", predicate: "action == '256'" } },
+
+          { constant: { field: "activity_id",   value: 2,         predicate: "action == '1024'" } },
+          { constant: { field: "activity_name", value: "Logoff",  predicate: "action == '1024'" } },
+          { constant: { field: "status_id",     value: 1,         predicate: "action == '1024'" } },
+          { constant: { field: "status",        value: "Success", predicate: "action == '1024'" } },
+
+          // The accessed appliance is both src (self-reported) and the auth target.
+          { copy: { from: "device.hostname", to: "dst_endpoint.hostname" } },
+
+          // Strip QNAP "no value" sentinels (---, (null)) before mapping.
+          { replace: { field: "ip",           regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "user",         regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "client_app",   regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "client_id",    regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "client_agent", regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          // The access "target" (msg) is often the placeholder "---"; blank it.
+          { replace: { field: "msg",          regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+
+          // Vendor-native -> OCSF dotted paths.
+          { rename: { from: "user",         to: "actor.user.name" } },
+          { rename: { from: "ip",           to: "src_endpoint.ip" } },
+          { rename: { from: "client_agent", to: "http_request.user_agent" } },
+          { rename: { from: "client_app",   to: "actor.app_name" } },
+          { rename: { from: "client_id",    to: "actor.session.uid" } },
+          { rename: { from: "action_result", to: "status_code" } },
+          { rename: { from: "action",        to: "action_id" } },        // preserve raw code
+          { rename: { from: "service",       to: "unmapped.qnap_service_id" } },
+          { rename: { from: "msg",           to: "message" } },
+
+          // Drop structural throwaways + access-irrelevant / always-empty fields.
+          { drop: { field: "log_priority" } },
+          { drop: { field: "sl_ver" } },
+          { drop: { field: "sl_hdr" } },
+          { drop: { field: "sd_raw" } },
+          { drop: { field: "mac" } },
+          { drop: { field: "extra_data" } },
+          { drop: { field: "source" } },
+          { drop: { field: "computer" } },
+          { drop: { field: "application" } }
+        ]
+      },
+
+      // ===== QuLog@Event -> unclassified administrative event ===============
+      {
+        predicate: "metadata.log_provider == 'QuLog@Event'",
+        transformations: [
+          { constant: { field: "severity_id", value: 1, predicate: "log_priority == '30'" } },
+          { constant: { field: "severity",    value: "Informational", predicate: "log_priority == '30'" } },
+          { constant: { field: "severity_id", value: 3, predicate: "log_priority == '28'" } },
+          { constant: { field: "severity",    value: "Medium",        predicate: "log_priority == '28'" } },
+
+          // Strip QNAP "no value" sentinels (---, (null)). `computer` keeps "localhost".
+          { replace: { field: "ip",           regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "user",         regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "application",  regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "category",     regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "computer",     regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "client_app",   regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "client_id",    regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+          { replace: { field: "client_agent", regexp: "^(?:---|\\(null\\))$", replacement: "" } },
+
+          { rename: { from: "user",         to: "actor.user.name" } },
+          { rename: { from: "ip",           to: "src_endpoint.ip" } },
+          { rename: { from: "client_agent", to: "http_request.user_agent" } },
+          { rename: { from: "msg",          to: "message" } },
+
+          // application / application_id / category / category_id / message_id /
+          // computer / client_app / client_id are kept as vendor-native descriptive
+          // fields — QuLog@Event has no clean OCSF activity class (see handoff).
+
+          { drop: { field: "log_priority" } },
+          { drop: { field: "sl_ver" } },
+          { drop: { field: "sl_hdr" } },
+          { drop: { field: "sd_raw" } },
+          { drop: { field: "mac" } },
+          { drop: { field: "extra_data" } },
+          { drop: { field: "source" } }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a community parser for QNAP QuLog logs.

## What
- `parsers/community/qnap_qulog_logs-latest/qnap_qulog.conf` — parsing logic for QNAP QuLog events
- `parsers/community/qnap_qulog_logs-latest/metadata.yaml` — parser metadata

## Notes
Single, self-contained addition under `parsers/community/`. No existing files modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)